### PR TITLE
add boolean CRON env var to support running container as a cronjob

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ docker run -d \
   -e SPOTIFY_USER_ID=<your spotify user id from the account page> # Option 1 \
   -e DEEZER_USER_ID=<your deezer user id> # Option 2 \
   -e DEEZER_PLAYLIST_ID= #<deezer playlist ids space seperated> # Option 3 \
+  -e CRON=<1 or 0> # Default 0, 1 = run one time and exit, 0 = run forever \
   -v <Path where you want to write missing tracks>:/data \
   --restart unless-stopped \
   rnagabhyrava/plexplaylistsync:latest
@@ -87,6 +88,7 @@ services:
       - SPOTIFY_USER_ID=<your spotify user id>
       - DEEZER_USER_ID=<your spotify user id>
       - DEEZER_PLAYLIST_ID= #<deezer playlist ids space seperated>
+      - CRON=<1 or 0> # Default 0, 1 = run one time and exit, 0 = run forever
     restart: unless-stopped
 
 ```

--- a/docker-compose-example.yml
+++ b/docker-compose-example.yml
@@ -20,4 +20,5 @@ services:
       - SPOTIFY_USER_ID=qwertyuiop # Option 1
       - DEEZER_USER_ID=9999999999 # Option 2
       - DEEZER_PLAYLIST_ID=1313621735 1963962142 # Option 3
+      - CRON=0 # If you want to run in a continuous loop, waiting for SECONDS_TO_WAIT between each run
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,4 +21,5 @@ services:
       - SPOTIFY_USER_ID=<your spotify user id>
       - DEEZER_USER_ID=<your spotify user id>
       - DEEZER_PLAYLIST_ID= #<deezer playlist ids space seperated>
+      - CRON=<1 or 0> # Default 0, 1 = run one time and exit, 0 = run forever
     restart: unless-stopped

--- a/plex-playlist-sync/run.py
+++ b/plex-playlist-sync/run.py
@@ -26,6 +26,7 @@ userInputs = UserInputs(
     spotify_user_id=os.getenv("SPOTIFY_USER_ID"),
     deezer_user_id=os.getenv("DEEZER_USER_ID"),
     deezer_playlist_ids=os.getenv("DEEZER_PLAYLIST_ID"),
+    run_as_cron=os.getenv("CRON", "0") == "1",
 )
 while True:
     logging.info("Starting playlist sync")
@@ -81,6 +82,10 @@ while True:
     logging.info("Deezer playlist sync complete")
 
     logging.info("All playlist(s) sync complete")
-    logging.info("sleeping for %s seconds" % userInputs.wait_seconds)
-
-    time.sleep(userInputs.wait_seconds)
+    
+    if userInputs.run_as_cron:
+        logging.info("run_as_cron is set to True, exiting")
+        break
+    else:
+        logging.info("sleeping for %s seconds" % userInputs.wait_seconds)
+        time.sleep(userInputs.wait_seconds)

--- a/plex-playlist-sync/utils/helperClasses.py
+++ b/plex-playlist-sync/utils/helperClasses.py
@@ -35,3 +35,5 @@ class UserInputs:
 
     deezer_user_id: str
     deezer_playlist_ids: str
+
+    run_as_cron: bool

--- a/plex-playlist-sync/utils/spotify.py
+++ b/plex-playlist-sync/utils/spotify.py
@@ -24,18 +24,23 @@ def _get_sp_user_playlists(
 
     try:
         sp_playlists = sp.user_playlists(user_id)
-        for playlist in sp_playlists["items"]:
-            playlists.append(
-                Playlist(
-                    id=playlist["uri"],
-                    name=playlist["name"] + suffix,
-                    description=playlist.get("description", ""),
-                    # playlists may not have a poster in such cases return ""
-                    poster=""
-                    if len(playlist["images"]) == 0
-                    else playlist["images"][0].get("url", ""),
+        while sp_playlists:
+            for playlist in sp_playlists['items']:
+                playlists.append(
+                    Playlist(
+                        id=playlist["uri"],
+                        name=playlist["name"] + suffix,
+                        description=playlist.get("description", ""),
+                        # playlists may not have a poster in such cases return ""
+                        poster=""
+                        if len(playlist["images"]) == 0
+                        else playlist["images"][0].get("url", ""),
+                    )
                 )
-            )
+            if sp_playlists['next']:
+                sp_playlists = sp.next(sp_playlists)
+            else:
+                sp_playlists = None
     except:
         logging.error("Spotify User ID Error")
     return playlists


### PR DESCRIPTION
The current configuration will run the container forever, but the vast majority of that time is spent simply waiting for the next run. With this variable, the user can set `CRON=1` and then schedule the docker container to run as a cronjob which will run once and exit on completion.